### PR TITLE
編集・削除機能の修正

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,10 +7,10 @@
       <%= link_to "by #{@prototype.user.name}",user_path(@prototype.user.id), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <div class="prototype__manage">
-
+         <% if user_signed_in? %>
           <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
           <%= link_to "削除する", prototype_path, method: :delete, class: :prototype__btn %>
-
+        <% end %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">


### PR DESCRIPTION
WHAT 　編集・削除機能の修正
WHY 　ログイン状態の投稿したユーザーだけに、「編集」「削除」のリンクが存在する状態にするため